### PR TITLE
Fix: Define GLOBAL_CSS before use

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -22,6 +22,21 @@ PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__)) # This will be ui.py's
 # This is a simple way to make them accessible to Taipy callbacks defined in this module.
 _app_callbacks: Dict[str, Callable] = {}
 
+# --- Global GUI Instance ---
+_gui_instance: Optional[Gui] = None
+
+# --- Global CSS (can be expanded) ---
+GLOBAL_CSS = """
+/* Add any global styles here. For example:
+body {
+    font-family: sans-serif;
+}
+.taipy-button {
+    margin: 5px;
+}
+*/
+"""
+
 # --- Taipy State Variables ---
 # These mirror the Streamlit session_state variables relevant to the UI.
 # Their initial values will be set in `create_gui` and then managed by Taipy.


### PR DESCRIPTION
This commit defines the `GLOBAL_CSS` variable as a multi-line string near the top of `ui.py`. This resolves a `NameError` that occurred because `GLOBAL_CSS` was used in the `get_gui_instance` function before it was defined.